### PR TITLE
Misc comments and proposed changes (part 1)

### DIFF
--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -23,7 +23,7 @@ Specification conventions
 -------------------------
 Throughout all of this document, bit sequences are always *big-endian*, and numbers
 are always *two's complement*.<br/>
-Keywords given in all caps are to be interpreted as stated in IETF RFC 2119.
+Keywords given in all caps are to be interpreted as stated in IETF BCP 14.
 
 A special notation is used to describe sequences of bits:
  - `u(N)`: specifies the data that follows is an unsigned integer of N bits.

--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -259,7 +259,7 @@ set in the `fec_covered` field.<br/>
 This MUST always be *greater than zero*.
 
 The `header_raptor_2` field allows for nearly-certain recovery of the first 192
-bits of the first packet's header when 2 consequtive segments are received.<br/>
+bits of the first packet's header when 2 consecutive segments are received.<br/>
 This allows knowledge of the data type, timestamp and duration for stream data
 packets when the very first packet is lost, which when combined with the FEC
 data could fully recover the starting data packet.<br/>

--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -343,10 +343,10 @@ If the `0x40` flag is set, then the packet data is incomplete, and at least ONE
 terminate the packet.
 
 The `data_compression` table is as follows:
-| Value | Name   | Description                                |
-|------:|:-------|:-------------------------------------------|
-|   0x0 | `NONE` | Packet data is uncompressed.               |
-|   0x1 | `ZSTD` | Packet data is compressed with Zstandard.  |
+| Value | Name   | Description                                                   |
+|------:|:-------|:--------------------------------------------------------------|
+|   0x0 | `NONE` | Packet data is uncompressed.                                  |
+|   0x1 | `ZSTD` | Packet data is compressed with Zstandard from IETF RFC 8878.  |
 
 Stream data segmentation
 ------------------------

--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -75,17 +75,17 @@ of how they're allocated.
 |           0x3 to 0x7 | [Stream initialization data](#init-data-packets)      |
 |                  0x8 | [Video information](#video-info-packets)              |
 |                  0x9 | [Index packets](#index-packets)                       |
-|           0xa to 0xe | [Metadata](#metadata-packets)                         |
+|           0xA to 0xE | [Metadata](#metadata-packets)                         |
 |         0x10 to 0x14 | [ICC profile](#icc-profile-packets)                   |
 |         0x20 to 0x24 | [Embedded font](#font-data-packets)                   |
-|     0x0100 to 0x01ff | [Stream data](#data-packets)                          |
-|         0xfe to 0xff | [Stream data segment](#data-segmentation)             |
-|         0xfc to 0xfd | [Stream FEC segment](#fec-segments)                   |
-|     0x4000 to 0x40ff | [User data](#user-data-packets)                       |
-|               0xf000 | [Stream duration](#stream-duration-packets)           |
-|               0xffff | [End of stream](#end-of-stream)                       |
+|     0x0100 to 0x01FF | [Stream data](#data-packets)                          |
+|         0xFE to 0xFF | [Stream data segment](#data-segmentation)             |
+|         0xFC to 0xFD | [Stream FEC segment](#fec-segments)                   |
+|     0x4000 to 0x40FF | [User data](#user-data-packets)                       |
+|               0xF000 | [Stream duration](#stream-duration-packets)           |
+|               0xFFFF | [End of stream](#end-of-stream)                       |
 |                      | **Reverse signalling only**                           |
-|     0x5000 to 0x50ff | [Reverse user data](#reverse-user-data)               |
+|     0x5000 to 0x50FF | [Reverse user data](#reverse-user-data)               |
 |               0x8001 | [Control data](#control-data)                         |
 |               0x8002 | [Feedback](#feedback)                                 |
 |               0x8003 | [Resend](#resend)                                     |

--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -29,8 +29,8 @@ A special notation is used to describe sequences of bits:
  - `u(N)`: specifies the data that follows is an unsigned integer of N bits.
  - `i(N)`: the same, but the data describes a signed integer is signed.
  - `b(N)`: the data is an opaque sequence of N bits that clients MUST NOT interpret as anything else.
- - `r(N)`: the data is a rational number, with a numerator of `i(N/2)` and
-   following that, a denominator of `i(N/2)`. The denominator MUST be greater than `0`.
+ - `r(N*2)`: the data is a rational number, with a numerator of `i(N)` and
+   following that, a denominator of `i(N)`. The denominator MUST be greater than `0`.
  - `C(N)`: Systematic Raptor code (IETF RFC 5053) of N bits with symbol size of 32-bits
    to correct and verify the data from the start of the packet to the start of this code.
    Implementations are allowed to skip checking it.

--- a/draft-qproto-spec.md
+++ b/draft-qproto-spec.md
@@ -78,9 +78,9 @@ of how they're allocated.
 |           0xA to 0xE | [Metadata](#metadata-packets)                         |
 |         0x10 to 0x14 | [ICC profile](#icc-profile-packets)                   |
 |         0x20 to 0x24 | [Embedded font](#font-data-packets)                   |
-|     0x0100 to 0x01FF | [Stream data](#data-packets)                          |
-|         0xFE to 0xFF | [Stream data segment](#data-segmentation)             |
 |         0xFC to 0xFD | [Stream FEC segment](#fec-segments)                   |
+|         0xFE to 0xFF | [Stream data segment](#data-segmentation)             |
+|     0x0100 to 0x01FF | [Stream data](#data-packets)                          |
 |     0x4000 to 0x40FF | [User data](#user-data-packets)                       |
 |               0xF000 | [Stream duration](#stream-duration-packets)           |
 |               0xFFFF | [End of stream](#end-of-stream)                       |


### PR DESCRIPTION
As discussed, I had a look at the specification and have a few comments and some proposed (tiny) changes.

> Implementations are allowed to only compare the first 4 bytes or 8 bytes to identify a Qproto session.

Can the raptor code give different values given the 4 bytes before are identical ?
Is it "only 4 or 8" or "only 4 or only 8" bytes ? In the former case you may omit the "or 8 bytes" and explain that in the case of 4 bytes, the raptor code is not checked.

> This signals the epoch of the timestamps, in nanoseconds since 00:00:00 UTC on 1 January 1970

In Matroska we use 2001/01/01 00:00:00 so that we are less limited by the UNIX times (and also it's the start of the millennium).

> Raptor code to correct and verify the previous contents of the packet.

Given the position of the raptor code is defined by the Descriptor value, do you need to include the Descriptor bits in it ? Isn't it a waste of bits ?

> This field MAY be zero, in which case the stream has no real-world time-relative context.

You mean the `epoch` field or the `global_seq` ? Given the next sentence I suppose it's the `epoch` field.

> If this field is non-zero, senders SHOULD ensure the epoch value is actual.

"actual" is rather vague. The only coherence check that could stand on its own is that it's not in the future.

In general I don't understand the use of the `time_descriptor` given there are many cases where the value doesn't matter.

> Monotonically incrementing per-packet global sequence number.

Since it's on 32 bits, what happens once one you are at 0xFFFFFFFF ?

> If the latter (codec_id, timebase AND related_stream_id) are to change an end of streampacket MUST be sent first.

What happens if the end of streampacket is lost over UDP ?

`derived_stream_id` doesn't much description on how to use it.

> If all bits in the mask 0x50fc are unset, related_stream_id MUST match stream_id, otherwise the stream with a related ID MUST exist.

And be a different ID ? Also the definition based on a mask is odd, because if you add `stream_flags` value that definition may not be true anymore.

> Per-stream monotonically incrementing packet number.

Does it have to start at 0 ? Does it overflow ?

> Implementations MUST feed the packets to the decoder in an incrementing order according to the dts field.

By the `dts` is not in the stream ? It should reference the more generic "coding order" as opposed to the "display order".

> The lower 8 bits are used as the pkt_flags field.

This is odd, you may use two `b(8)` fields .

zlib data compression might be added, it usually gives a good ratio with subtitle content.

> Negative offset of the previous index packet, if any, in bytes, relative to the current position. 

From start of the Index packet or the beginning of the field ? Bytes excluded ? An example could clarify this.

> Must be exact.

**MUST** be exact. ?

<read up to Font data packets for now>